### PR TITLE
Avoid timer loops without a wait interval.

### DIFF
--- a/zenscript-language.el
+++ b/zenscript-language.el
@@ -378,7 +378,9 @@ Internally, this uses `zenscript--parse-tokens' and `zenscript--tokenize-buffer'
     (with-current-buffer buffer
       (when (eq major-mode 'zenscript-mode)
         (run-with-idle-timer
-         zenscript-buffer-parse-idle-period
+         (let ((cit (current-idle-time)))
+           (if cit (time-add cit zenscript-buffer-parse-idle-period)
+             zenscript-buffer-parse-idle-period))
          ()
          (lambda ()
            (zenscript-parse-buffer buffer)))


### PR DESCRIPTION
I found that having a zenscript buffer open when Emacs was idle was causing emacs to peg a CPU.  The culprit appears to be in the `run-with-idle-timer` invocation in `zenscript-parse-buffer`.  After the initial idle time it will get called again immediately, and then immediately again.  I debugged what is happening by adding a `message` call to the beginning of `zenscript-parse-buffer`.

The elisp info page for **Idle Timers** states:

> Similarly, do not write an idle timer function that sets up another idle
timer (including the same idle timer) with SECS argument less than or
equal to the current idleness time.  Such a timer will run almost
immediately, and continue running again and again, instead of waiting
for the next time Emacs becomes idle.  The correct approach is to
reschedule with an appropriate increment of the current value of the
idleness time, as described below.

I attempted to do the simple thing, just calling `(time-add (current-idle-time) length)`, but for some reason the timer never triggered using that, so I special cased when `(current-idle-time)` returned nil.  This appears to do what is needed, though the time it takes Emacs to become "idle" seems overlong in my experiments (though not too long).
